### PR TITLE
Fix crash in service discovery

### DIFF
--- a/src/service-discovery.js
+++ b/src/service-discovery.js
@@ -16,7 +16,7 @@ function dnsServiceResolved(err, interface, protocol, name, type, domain, host, 
 
   let service = {name, host, address, port};
   for (let item of txt) {
-    let textItem = Buffer(item.data).toString('utf8');
+    let textItem = Buffer(item).toString('utf8');
     let [key, value] = textItem.split('=');
     service[key] = value;
   }


### PR DESCRIPTION
In `src/service-discovery.js`, `dnsServiceResolved()`, `item.data` is
undefined:

    $ node index.js -a qml/app3
    node index.js -a qml/app3
    Example app listening on port 3000!
    buffer.js:262
      throw new TypeError(kFromErrorMsg);
      ^

    TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.
	at fromObject (buffer.js:262:9)
	at Function.Buffer.from (buffer.js:101:10)
	at Buffer (buffer.js:80:17)
	at Object.dnsServiceResolved (src/service-discovery.js:22:20)
	at EventEmitter.<anonymous> (node_modules/dbus-native/lib/bus.js:113:26)
	at emitOne (events.js:96:13)
	at EventEmitter.emit (events.js:188:7)
	at node_modules/dbus-native/index.js:112:12
	at Socket.<anonymous> (node_modules/dbus-native/lib/message.js:52:9)
	at emitNone (events.js:86:13)